### PR TITLE
Remove "dev-master" requirement for everyman/neo4jphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": ">=5.3.3",
         "silex/silex": "~1.0",
-        "everyman/neo4jphp": "dev-master"
+        "everyman/neo4jphp": "~0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
The service provider depends on dev-master. As the only interaction it has with neo4j is the constructor in the client, it is most likely safe to ease up on this requirement. 

0.1.0 is the latest tagged release of everyman/neo4jphp.
